### PR TITLE
Improved interpretor path support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@zero-plusplus/autohotkey-utilities": "github:zero-plusplus/node-autohotkey-utilities#develop",
         "async-lock": "^1.2.8",
+        "command-exists": "^1.2.9",
         "convert-hrtime": "^3.0.0",
         "fast-glob": "^3.2.7",
         "fast-xml-parser": "^3.16.0",
@@ -1643,6 +1644,11 @@
       "bin": {
         "color-support": "bin.js"
       }
+    },
+    "node_modules/command-exists": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
+      "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
     },
     "node_modules/commander": {
       "version": "6.2.1",
@@ -10747,6 +10753,11 @@
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
       "dev": true
+    },
+    "command-exists": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
+      "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
     },
     "commander": {
       "version": "6.2.1",

--- a/package.json
+++ b/package.json
@@ -959,6 +959,7 @@
   "dependencies": {
     "@zero-plusplus/autohotkey-utilities": "github:zero-plusplus/node-autohotkey-utilities#develop",
     "async-lock": "^1.2.8",
+    "command-exists": "^1.2.9",
     "convert-hrtime": "^3.0.0",
     "fast-glob": "^3.2.7",
     "fast-xml-parser": "^3.16.0",


### PR DESCRIPTION
Although I am aware of your policy of not accepting pull requests, I am leaving this here as a base for a potential fix for issue #303 whenever you get time to deal with this. Modify it as you wish. 

This PR adds `existsSyncEx` and `commandExistsSync` functions to support accepting a command, file, or symlink as runtime paths. This fixes the issue where `existsSync` returns "false" in the case of a symlink pointing to the WindowsApps restricted folder. 
1) `commandExistsSync` requires the package `command-exists`, this has been added to package.json
2) `existsSyncEx` uses `lstatSync` to check whether a file or symlink exists by checking for the ENOENT error. `lstatSync` is used instead of `statSync` because the latter fails with a "permission denied" error in cases of a symlink pointing to a restricted permission file. 

For example, if AHK Microsoft Store edition is installed, `commandExistsSync` permits `AutoHotkey` command to be used instead of a full path, and `existsSyncEx` permits the symlink `C:/Users/CURRENTUSER/AppData/Local/Microsoft/WindowsApps/AutoHotkey.exe` which previously failed. 